### PR TITLE
Added Balancer Writeup

### DIFF
--- a/product/adhoc_analyses/2022-01-24 Balancer_Solution_Writeup.ipynb
+++ b/product/adhoc_analyses/2022-01-24 Balancer_Solution_Writeup.ipynb
@@ -1,0 +1,541 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "40e075d7-2ac8-46ad-8681-fcb67fdea3da",
+   "metadata": {},
+   "source": [
+    "# Basics: From the Balancer White Paper"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10163f5f-3cef-4e26-b445-91cbe76eaa4a",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "Balancer Invariant Equation:\n",
+    "    $$K = \\Pi_{j=1}^n B_j^{W_j}$$\n",
+    "where\n",
+    "* $K$: The Invariant Constant \n",
+    "* $j$: Index of token\n",
+    "* $n$: Number of tokens\n",
+    "* $B_j$: Balance of token $j$\n",
+    "* $N_j$: Normalized weight of token $j$\n",
+    "\n",
+    "\n",
+    "Spot Price Equation:\n",
+    "$SP_i^o = \\frac{\\frac{B_i}{W_i}}{\\frac{B_o}{W_o}}$\n",
+    "\n",
+    "* $B_i$: Balance of token going <u>into</u> the pool\n",
+    "* $B_o$: Balance of token coming <u>out</u> of the pool\n",
+    "* $N_i$: Normalized weight of token going into the pool\n",
+    "* $N_o$: Normalized weight of token coming out of the pool\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "998b1bb6-671f-4676-abde-49afef175234",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "298cd42a-3ae7-4009-b02a-0476c54a94f4",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d648680-f89c-44d4-9e58-1c514932740a",
+   "metadata": {},
+   "source": [
+    "# Example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "889bc95b-58e3-4135-834d-e2675d844dbc",
+   "metadata": {},
+   "source": [
+    "Ex:  Prices $1 BTC = \\$1000$, $1 ETH = \\$250$\n",
+    "\n",
+    "<u>Market price</u> of $ETH$ to $BTC$ is $4$. (Give $4 ETH$, get $1 BTC$).\n",
+    "\n",
+    "\n",
+    "Suppose we hold $1000 BTC$ and $1000 ETH$ (To have an $80-20$ $BTC-ETH$ portfolio)\n",
+    "\n",
+    "Our weights are then $W_{BTC} = .8$, $W_{ETH} = .2$\n",
+    "\n",
+    "The <u>spot price</u> of $ETH$ to $BTC$ according to the balancer paper formula is \n",
+    "\n",
+    "\n",
+    "$SP_{ETH}^{BTC} = \\frac{\\frac{B_{ETH}}{W_{ETH}}}{\\frac{B_{BTC}}{W_{BTC}}} = \\frac{\\frac{1000}{.2}}{\\frac{1000}{.8}} = 4$  (Give $4 ETH$, get $1 BTC$).\n",
+    "\n",
+    "In this situation, the market price and the spot price are in agreement.\n",
+    "\n",
+    "\n",
+    "Suppose we adjust the weights of our portfolio to .5 and .5.\n",
+    "\n",
+    "Then the pool's spot price of ETH to BTC is \n",
+    "\n",
+    "$SP_{ETH}^{BTC} = \\frac{\\frac{B_{ETH}}{W_{ETH}}}{\\frac{B_{BTC}}{W_{BTC}}} = \\frac{\\frac{1000}{.5}}{\\frac{1000}{.5}} = 1$  (Give $1 ETH$, get $1 BTC$).\n",
+    "\n",
+    "\n",
+    "As a response, the market will arbitrage by purchasing BTC from our pool until the pool's spot price returns to the market spot price (${SP_{MKT}}_{ETH}^{BTC} = 4$). The Balances of BTC and ETH held in the portfolio can be calculated by solving the following equations.\n",
+    "\n",
+    "${SP_{MKT}}_{ETH}^{BTC} = \\frac{{B_{ETH}}_{new}}{{B_{BTC}}_{new}}\\frac{W_{BTC}}{W_{ETH}}$ $~~~~~~~~$ (Spot price Equation)\n",
+    "\n",
+    "${B_{ETH}}_{new}^{W_{ETH}}{B_{BTC}}_{new}^{W_{BTC}} = {B_{ETH}}_{old}^{W_{ETH}}{B_{BTC}}_{old}^{W_{BTC}}$ $~~~~~~~~$ (Balancer Invariant Equation)\n",
+    "\n",
+    "\n",
+    "We have two unknowns, ${B_{ETH}}_{new}$ and ${B_{BTC}}_{new}$. The rest of the variables are known --\n",
+    " \n",
+    "* ${SP_{MKT}}_{ETH}^{BTC} = 4$ Market Spot Price\n",
+    "* $W_{BTC} = .5$ Weight of BTC Token\n",
+    "* $W_{ETH} = .5$ Weight of ETH Token\n",
+    "* ${B_{BTC}}_{old} = 1000$ Balance of BTC Token (pre-arbitrage)\n",
+    "* ${B_{ETH}}_{old} = 1000$ Balance of ETH Token (pre-arbitrage)\n",
+    "\n",
+    "Plugging our values into these two equations we get:\n",
+    "\n",
+    "$4 =  \\frac{{B_{ETH}}_{new}}{{B_{BTC}}_{new}} \\frac{.5}{.5}$\n",
+    "\n",
+    "${B_{ETH}}_{new}^{.5}{B_{BTC}}_{new}^{.5} = 1000^{.5} 1000^{.5}$ \n",
+    "\n",
+    "Solving For ${B_{ETH}}_{new}$ in each equation gives\n",
+    "\n",
+    "${B_{ETH}}_{new} = 4 {B_{BTC}}_{new}$\n",
+    "\n",
+    "${B_{ETH}}_{new} = \\frac{10^6}{{B_{BTC}}_{new}} $\n",
+    "\n",
+    "We can then solve for ${B_{BTC}}_{new}$ to get ${B_{BTC}}_{new} = 500$ , and then plug in the result to get ${B_{ETH}}_{new} = 2000$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2fb3b829-7a9f-4f26-b455-29239d18aed4",
+   "metadata": {},
+   "source": [
+    "# General N-token Solution"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de622637-3e3a-4090-a2ec-ac526798b30d",
+   "metadata": {},
+   "source": [
+    "Assume we have n tokens indexed $1,...,n$. \n",
+    "\n",
+    "Assume we have the initial balances of each token, represented by ${B_1}_{old},...,{B_n}_{old}$\n",
+    "\n",
+    "Assume we have the market spot prices from token $1$ to each of the other $n-1$ tokens. ${SP_{MKT}}_1^k$ for $k\\in 2,...,n$. \n",
+    "\n",
+    "Suppose we hold ${B_1}_{old},...,{B_n}_{old}$ balances of token $1$,...,token $n$ respectively.\n",
+    "\n",
+    "Suppose we set the weights of our portfolio to $W_1,...,W_n$ where $\\sum_{j=1}^n W_j = 1$. \n",
+    "\n",
+    "Let $C = \\Pi_{j=1}^n {B_j}_{old}^{W_j}$ be the invariant constant.\n",
+    "\n",
+    "Assume that the market spot price remains constant throughout the arbitrage. \n",
+    "\n",
+    "### We will show that the new balances of each token in the portfolio are \n",
+    "\n",
+    "${B_1}_{new} = C\\cdot \\Pi_{j=2}^n ({SP_{MKT}}_1^j \\frac{W_1}{W_j})^{W_j}  $ \n",
+    "\n",
+    "\n",
+    "and ${B_k}_{new} = \\frac{{B_1}_{new}}{{SP_{MKT}}_1^k} \\frac{W_k}{W_1}$ for $k \\in {2,...,n}$\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7b569e9f-fee2-43f3-a36e-261caa173a4d",
+   "metadata": {},
+   "source": [
+    "# Proof"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e60a668-5e4a-4857-a3eb-8952964e84f4",
+   "metadata": {},
+   "source": [
+    "As in our example, we have a system of $n$ equations and $n$ unknowns.\n",
+    "\n",
+    "Explicity, We have $n-1$ market spot price equations, and $1$ invariant equation.\n",
+    "\n",
+    "${SP_{MKT}}_1^k = \\frac{{B_1}_{new}}{{B_k}_{new}} \\frac{W_k}{W_1}$ for $k \\in {2,...,n}$\n",
+    "\n",
+    "and\n",
+    "\n",
+    "$\\Pi_{j=1}^n {B_j}_{new}^{W_j} = \\Pi_{j=1}^n {B_j}_{old}^{W_j}$\n",
+    "\n",
+    "\n",
+    "First, we can solve for ${B_k}_{new}$ in the $n-1$ market spot price equations to get \n",
+    "\n",
+    "${B_k}_{new} = \\frac{{B_1}_{new}}{{SP_{MKT}}_1^k }\\frac{W_k}{W_1}$\n",
+    "\n",
+    "Notice that the only unknown in this family of equations is ${B_1}_{new}$.\n",
+    "\n",
+    "We now solve for ${B_1}_{new}$. Starting from the invariant equation, we get\n",
+    "\n",
+    "$\\Pi_{j=1}^n {B_j}_{new}^{W_j} = C$\n",
+    "\n",
+    "${B_1}_{new}^{W_1} = \\frac{C} {\\Pi_{j=2}^n {B_j}_{new}^{W_j}}$\n",
+    "\n",
+    "${B_1}_{new}^{W_1} = \\frac{C} {\\Pi_{j=2}^n (\\frac{{B_1}_{new}}{{SP_{MKT}}_1^j }\\frac{W_j}{W_1})^{W_j}}$\n",
+    "\n",
+    "${B_1}_{new}^{W_1} = \\frac{C \\cdot \\Pi_{j=2}^n ({SP_{MKT}}_1^j \\frac{W_1}{W_j})^{W_j}} { \\Pi_{j=2}^n {B_1}_{new}^{W_j}}  $\n",
+    "\n",
+    "${B_1}_{new}^{\\sum_{j=1}^n W_j} = C \\cdot \\Pi_{j=2}^n ({SP_{MKT}}_1^j \\frac{W_1}{W_j})^{W_j}  $ (Recall that $\\sum_{j=1}^n W_j = 1$ by construction)\n",
+    "\n",
+    "${B_1}_{new} = C\\cdot \\Pi_{j=2}^n ({SP_{MKT}}_1^j \\frac{W_1}{W_j})^{W_j}  $ \n",
+    "\n",
+    "\n",
+    "We can then substitute the value of ${B_1}_{new}$ to get each ${B_k}_{new}$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c4dbfa6-7cd8-4d9b-8e2a-53b79801330f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab03d760-4267-46c2-b364-6486a6fbcce7",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff0e2df2-4016-4eb4-be00-34cbd188ecec",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf91cffe-291e-4d84-8903-6964ffbf3268",
+   "metadata": {},
+   "source": [
+    "# Spreadsheet Link\n",
+    "https://docs.google.com/spreadsheets/d/16QjW7IlNXxXYJ8IE5Dla7CW6mu0qGsuQ-ZAHnzpsV7k/edit#gid=0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9eeb93e-9e66-4bf9-9db7-5163d960adf2",
+   "metadata": {},
+   "source": [
+    "# Code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8830cdf1-c6f0-4744-aefa-3b183c77335b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d774659f-3d01-4e4b-a4f9-935ffe39b830",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def calc_new_balances(mkt_sp_vec,balance_old_vec,weights_new_vec):\n",
+    "    '''\n",
+    "    Suppose there are n tokens. Recall that tokens are indexed from 1 to n (and not 0 to n-1).\n",
+    "    \n",
+    "    Inputs:\n",
+    "    mkt_sp_vec: a n-1 length np.array whose i'th index represents the market spot price from the 1st token to the i+2'th token.\n",
+    "        e.g 0th index represents spot price from token 1 to token 2, 1st index represents spot price from token 1 to token 3, n-2th index represents spot price form token 1 to token n.\n",
+    "    balance_old_vec: a n-length np array whose i'th index represents the pre-arbitrage balance of token i+1\n",
+    "    weights_new_vec: a n-length np array whose i'th index represents the new weights of token i+1\n",
+    "    \n",
+    "    Output:\n",
+    "    balance_new_vec: a n-length np array whose i'th index represents the post-arbitrage balance of token i+1\n",
+    "    '''\n",
+    "    \n",
+    "    invariant_c = np.product(np.power(balance_old_vec,weights_new_vec))\n",
+    "    #print('invariant_c',invariant_c)\n",
+    "    #print(mkt_sp_vec * weights_new_vec[0])\n",
+    "    \n",
+    "    B_1_new = invariant_c * np.product(np.power(mkt_sp_vec * weights_new_vec[0] / weights_new_vec[1:], weights_new_vec[1:])) # should be length 1 /scalar\n",
+    "    #print('B_1_new',B_1_new)\n",
+    "    \n",
+    "    B_k_new_vec = B_1_new / mkt_sp_vec * weights_new_vec[1:] / weights_new_vec[0] #should be length n-1\n",
+    "    #print(len(B_k_new_vec))\n",
+    "    \n",
+    "    balance_new_vec =  np.concatenate([np.array([B_1_new]), B_k_new_vec])\n",
+    "    #print(balance_new_vec)\n",
+    "    \n",
+    "    return balance_new_vec\n",
+    "    \n",
+    "    \n",
+    "    \n",
+    "    \n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e60c671-396d-49fb-afbc-ec528c24a79b",
+   "metadata": {},
+   "source": [
+    "# Example 0, Balances at equilibrium"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "9b038cae-6ed7-4952-8351-9576b7d6b6b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mkt_sp_vec = np.array([.25])\n",
+    "balance_old_vec = np.array([1000,2000])\n",
+    "weights_old_vec = np.array([2/3,1/3]) # Note that this is here to show the initial equilibrium. \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3150455-d6b5-45e6-8f7f-2ca637339b46",
+   "metadata": {},
+   "source": [
+    "### Showing the Equilibrium at market spot price of .25"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "cdac2eb3-dd49-4ef2-b375-933ecaa62fa9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Old Balances [1000 2000]\n",
+      "Showing Equilibrium: Balances \"after a shift\" \n",
+      "Total Value in terms of token 1:  1499.9999999999995\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Old Balances', balance_old_vec)\n",
+    "new_balance = calc_new_balances(mkt_sp_vec,balance_old_vec,weights_old_vec)\n",
+    "print('Showing Equilibrium: Balances \"after a shift\" ', )\n",
+    "print('Total Value in terms of token 1: ', new_balance[0] + np.dot(mkt_sp_vec,new_balance[1:]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11eaeda7-e076-4b63-a460-3da1ec90a56f",
+   "metadata": {},
+   "source": [
+    "In this case, because the balances do not shift at all, the pool is at equilibrium with the market spot price."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d093c51a-3f3d-4d82-b639-1d0e5019e26a",
+   "metadata": {},
+   "source": [
+    "# Example 1, Balances after a weight shift."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d04d57d2-a56b-4a51-9919-a528ba2a1c91",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weights_new_vec = np.array([.5,.5])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "40344278-be67-4a7d-919c-c93bc62a64d5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Old Balances [1000 2000]\n",
+      "Balances after a shift [ 707.10678119 2828.42712475]\n",
+      "Total Value in terms of token 1:  1414.213562373095\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Old Balances', balance_old_vec)\n",
+    "new_balance = calc_new_balances(mkt_sp_vec,balance_old_vec,weights_new_vec)\n",
+    "print('Balances after a shift', new_balance)\n",
+    "print('Total Value in terms of token 1: ', new_balance[0] + np.dot(mkt_sp_vec,new_balance[1:]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53bc94d5-41b4-466c-89f6-1fd3859fb392",
+   "metadata": {},
+   "source": [
+    "# Example 2, Balances after two weight shifts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "ccfbca0a-f65c-45fb-90a6-36bcf6a35943",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weights_new_vec_1 = np.array([.6,.4])\n",
+    "weights_new_vec_2 = np.array([.5,.5])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "5a40d3f0-4e45-406d-87f5-0a7144956ea2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Old Balances [1000 2000]\n",
+      "Balances after shift 1 [ 891.30122898 2376.80327729]\n",
+      "Total Value in terms of token 1:  1485.502048305003\n",
+      "Balances after shift 2 [ 727.74440604 2910.97762417]\n",
+      "Total Value in terms of token 1:  1455.4888120826022\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Old Balances', balance_old_vec)\n",
+    "\n",
+    "balance_after_shift_1 = calc_new_balances(mkt_sp_vec,balance_old_vec,weights_new_vec_1)\n",
+    "print('Balances after shift 1',balance_after_shift_1)\n",
+    "print('Total Value in terms of token 1: ', balance_after_shift_1[0] + np.dot(mkt_sp_vec,balance_after_shift_1[1:]))\n",
+    "\n",
+    "balance_after_shift_2 = calc_new_balances(mkt_sp_vec,balance_after_shift_1,weights_new_vec_2)\n",
+    "print('Balances after shift 2', balance_after_shift_2)\n",
+    "print('Total Value in terms of token 1: ', balance_after_shift_2[0] + np.dot(mkt_sp_vec,balance_after_shift_2[1:]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7eb67afb-8c5c-4f73-a733-e29ff0435689",
+   "metadata": {},
+   "source": [
+    "# Example 3, Balances after 10000 weight shifts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "f541e6ce-3d23-4d75-b3d3-d102903a7abe",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Balances after shift 999: [ 975.02190058 2099.90869518]\n",
+      "Total Value in terms of token 1 after shift 999: 1499.9990743781573\n",
+      "Balances after shift 1999: [ 950.0188417  2199.91730514]\n",
+      "Total Value in terms of token 1 after shift 1999: 1499.998167984469\n",
+      "Balances after shift 2999: [ 925.01582364 2299.92582061]\n",
+      "Total Value in terms of token 1 after shift 2999: 1499.9972787928732\n",
+      "Balances after shift 3999: [ 900.01284394 2399.93424075]\n",
+      "Total Value in terms of token 1 after shift 3999: 1499.9964041261328\n",
+      "Balances after shift 4999: [ 875.00990044 2499.94256438]\n",
+      "Total Value in terms of token 1 after shift 4999: 1499.9955415367915\n",
+      "Balances after shift 5999: [ 850.00699126 2599.95078999]\n",
+      "Total Value in terms of token 1 after shift 5999: 1499.9946887601282\n",
+      "Balances after shift 6999: [ 825.00411474 2699.95891574]\n",
+      "Total Value in terms of token 1 after shift 6999: 1499.9938436743996\n",
+      "Balances after shift 7999: [ 800.00126942 2799.96693939]\n",
+      "Total Value in terms of token 1 after shift 7999: 1499.9930042666363\n",
+      "Balances after shift 8999: [ 774.99845401 2899.97485835]\n",
+      "Total Value in terms of token 1 after shift 8999: 1499.9921686022396\n",
+      "Balances after shift 9999: [ 749.9956674  2999.98266959]\n",
+      "Total Value in terms of token 1 after shift 9999: 1499.9913347974502\n"
+     ]
+    }
+   ],
+   "source": [
+    "num_weights=10000\n",
+    "weights_array = np.vstack([\n",
+    "    np.linspace(2/3,.5,num=num_weights),\n",
+    "    np.linspace(1/3,.5,num=num_weights)\n",
+    "])\n",
+    "prev_balance = balance_old_vec\n",
+    "for ii in range(num_weights):\n",
+    "    weights_new = weights_array[:,ii]\n",
+    "    balance_after_shift_ii = calc_new_balances(mkt_sp_vec, prev_balance, weights_new)\n",
+    "    if (ii + 1) % 1000 == 0:\n",
+    "        print('Balances after shift {}: {}'.format(ii, balance_after_shift_ii))\n",
+    "        print('Total Value in terms of token 1 after shift {}: {}'.format(ii,balance_after_shift_ii[0] + np.dot(mkt_sp_vec,balance_after_shift_ii[1:])))\n",
+    "    prev_balance = balance_after_shift_ii\n",
+    "\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "880fe2f0-21e2-44cf-a154-48173a409a88",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d130e3f-920a-4d1c-8678-38bd317f1cb3",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Summary: Math for calculating new balances after arbitrarily adjusting the weights. 


This work provides 3 contributions:
1. Equations (and proof/derivation of equation) for calculating the new balances in a balancer portfolio after arbitrarily adjusting the weights, and allowing the market to arbitrage.
2. A python function that can be used to calculate the new balances after weight shift and arbitrage.
3. A spreadsheet with a toy example.