### PR TITLE
Update namespace

### DIFF
--- a/abstractions/table_indexcoop_derivative_tokens.sql
+++ b/abstractions/table_indexcoop_derivative_tokens.sql
@@ -11,6 +11,10 @@ create table if not exists dune_user_generated.indexcoop_derivative_tokens
   token_type varchar          
 );
 
+create index on dune_user_generated.indexcoop_derivative_tokens(token_address);
+create index on dune_user_generated.indexcoop_derivative_tokens(symbol);
+create index on dune_user_generated.indexcoop_derivative_tokens(base_symbol); 
+
 truncate table dune_user_generated.indexcoop_derivative_tokens;
 
 insert into dune_user_generated.indexcoop_derivative_tokens 

--- a/abstractions/table_indexcoop_fee_structure.sql
+++ b/abstractions/table_indexcoop_fee_structure.sql
@@ -12,7 +12,7 @@ CREATE TABLE if not exists dune_user_generated.indexcoop_fee_structure
         methodologist_split decimal
     )
 ;
-
+create index on dune_user_generated.indexcoop_fee_structure(symbol);
 truncate table dune_user_generated.indexcoop_fee_structure;
 
 insert into dune_user_generated.indexcoop_fee_structure

--- a/abstractions/view_indexcoop_prices_daily.sql
+++ b/abstractions/view_indexcoop_prices_daily.sql
@@ -1,3 +1,5 @@
+-- Ethereum - 
+
 CREATE OR REPLACE VIEW 
 dune_user_generated.indexcoop_prices_daily as
 

--- a/product/eth2x/eth2x-product-dash/eth2x-cumulative-revenue-cost.sql
+++ b/product/eth2x/eth2x-product-dash/eth2x-cumulative-revenue-cost.sql
@@ -1,3 +1,6 @@
+-- TODO: This query had its namespace updated. Double check the data sources to ensure there's no duplication.
+-- TODO: Find the prod dune query that this code refers to.
+
 -- CONTRACTS
 -- BaseManager --> 0x445307De5279cD4B1BcBf38853f81b190A806075
 -- SupplyCapIssuanceHook --> 0x0F1171C24B06ADed18d2d23178019A3B256401D3

--- a/product/eth2x/eth2x-product-dash/eth2x-cumulative-revenue-cost.sql
+++ b/product/eth2x/eth2x-product-dash/eth2x-cumulative-revenue-cost.sql
@@ -241,7 +241,7 @@ fa_transactions AS (
         call_tx_hash AS hash,
         call_block_time AS block_time,
         'update fee recipient' AS transaction
-    FROM indexcoop."FeeSplitAdapter_call_updateFeeRecipient"
+    FROM setprotocol_v2."FeeSplitAdapter_call_updateFeeRecipient"
     where contract_address = '\x26F81381018543eCa9353bd081387F68fAE15CeD'
     
     UNION ALL 
@@ -251,7 +251,7 @@ fa_transactions AS (
         evt_tx_hash AS hash,
         evt_block_time AS block_time,
         'transfer ownership' AS transaction
-    FROM indexcoop."FeeSplitAdapter_evt_OwnershipTransferred"
+    FROM setprotocol_v2."FeeSplitAdapter_evt_OwnershipTransferred"
     where contract_address = '\x26F81381018543eCa9353bd081387F68fAE15CeD'
     
     UNION ALL 
@@ -261,7 +261,7 @@ fa_transactions AS (
         evt_tx_hash AS hash,
         evt_block_time AS block_time,
         'accrue fees' AS transaction
-    FROM indexcoop."FeeSplitAdapter_evt_FeesAccrued"
+    FROM setprotocol_v2."FeeSplitAdapter_evt_FeesAccrued"
     where contract_address = '\x26F81381018543eCa9353bd081387F68fAE15CeD'
 
     UNION ALL 
@@ -271,7 +271,7 @@ fa_transactions AS (
         evt_tx_hash AS hash,
         evt_block_time AS block_time,
         'register upgrade' AS transaction
-    FROM indexcoop."FeeSplitAdapter_evt_UpgradeRegistered"
+    FROM setprotocol_v2."FeeSplitAdapter_evt_UpgradeRegistered"
     where contract_address = '\x26F81381018543eCa9353bd081387F68fAE15CeD'
 
     UNION ALL
@@ -281,7 +281,7 @@ fa_transactions AS (
         evt_tx_hash AS hash,
         evt_block_time AS block_time,
         'update caller status' AS transaction
-    FROM indexcoop."FeeSplitAdapter_evt_CallerStatusUpdated"
+    FROM setprotocol_v2."FeeSplitAdapter_evt_CallerStatusUpdated"
     where contract_address = '\x26F81381018543eCa9353bd081387F68fAE15CeD'
 
     UNION ALL
@@ -291,7 +291,7 @@ fa_transactions AS (
         evt_tx_hash AS hash,
         evt_block_time AS block_time,
         'update anyone callable' AS transaction
-    FROM indexcoop."FeeSplitAdapter_evt_AnyoneCallableUpdated"
+    FROM setprotocol_v2."FeeSplitAdapter_evt_AnyoneCallableUpdated"
     where contract_address = '\x26F81381018543eCa9353bd081387F68fAE15CeD'
 ),
 

--- a/product/eth2x/eth2x-product-dash/eth2x-daily-revenue-cost.sql
+++ b/product/eth2x/eth2x-product-dash/eth2x-daily-revenue-cost.sql
@@ -1,5 +1,6 @@
 
 -- https://duneanalytics.com/queries/53279/105647
+-- TODO: This query had its namespace updated. Double check the data sources to ensure there's no duplication.
 
 -- V2 query here - https://duneanalytics.com/queries/93652
 -- CONTRACTS

--- a/product/eth2x/eth2x-product-dash/eth2x-daily-revenue-cost.sql
+++ b/product/eth2x/eth2x-product-dash/eth2x-daily-revenue-cost.sql
@@ -245,7 +245,7 @@ fa_transactions AS (
         call_tx_hash AS hash,
         call_block_time AS block_time,
         'update fee recipient' AS transaction
-    FROM indexcoop."FeeSplitAdapter_call_updateFeeRecipient"
+    FROM setprotocol_v2."FeeSplitAdapter_call_updateFeeRecipient"
     where contract_address = '\x26F81381018543eCa9353bd081387F68fAE15CeD'
     
     UNION ALL 
@@ -255,7 +255,7 @@ fa_transactions AS (
         evt_tx_hash AS hash,
         evt_block_time AS block_time,
         'transfer ownership' AS transaction
-    FROM indexcoop."FeeSplitAdapter_evt_OwnershipTransferred"
+    FROM setprotocol_v2."FeeSplitAdapter_evt_OwnershipTransferred"
     where contract_address = '\x26F81381018543eCa9353bd081387F68fAE15CeD'
     
     UNION ALL 
@@ -265,7 +265,7 @@ fa_transactions AS (
         evt_tx_hash AS hash,
         evt_block_time AS block_time,
         'accrue fees' AS transaction
-    FROM indexcoop."FeeSplitAdapter_evt_FeesAccrued"
+    FROM setprotocol_v2."FeeSplitAdapter_evt_FeesAccrued"
     where contract_address = '\x26F81381018543eCa9353bd081387F68fAE15CeD'
 
     UNION ALL 
@@ -275,7 +275,7 @@ fa_transactions AS (
         evt_tx_hash AS hash,
         evt_block_time AS block_time,
         'register upgrade' AS transaction
-    FROM indexcoop."FeeSplitAdapter_evt_UpgradeRegistered"
+    FROM setprotocol_v2."FeeSplitAdapter_evt_UpgradeRegistered"
     where contract_address = '\x26F81381018543eCa9353bd081387F68fAE15CeD'
 
     UNION ALL
@@ -285,7 +285,7 @@ fa_transactions AS (
         evt_tx_hash AS hash,
         evt_block_time AS block_time,
         'update caller status' AS transaction
-    FROM indexcoop."FeeSplitAdapter_evt_CallerStatusUpdated"
+    FROM setprotocol_v2."FeeSplitAdapter_evt_CallerStatusUpdated"
     where contract_address = '\x26F81381018543eCa9353bd081387F68fAE15CeD'
 
     UNION ALL
@@ -295,7 +295,7 @@ fa_transactions AS (
         evt_tx_hash AS hash,
         evt_block_time AS block_time,
         'update anyone callable' AS transaction
-    FROM indexcoop."FeeSplitAdapter_evt_AnyoneCallableUpdated"
+    FROM setprotocol_v2."FeeSplitAdapter_evt_AnyoneCallableUpdated"
     where contract_address = '\x26F81381018543eCa9353bd081387F68fAE15CeD'
 ),
 

--- a/product/eth2x/eth2x-product-dash/eth2x-revenue-cost-breakdown.sql
+++ b/product/eth2x/eth2x-product-dash/eth2x-revenue-cost-breakdown.sql
@@ -1,3 +1,6 @@
+-- TODO: This query had its namespace updated. Double check the data sources to ensure there's no duplication.
+-- TODO: Find the prod dune query that this code refers to.
+
 -- CONTRACTS
 -- BaseManager --> 0x445307De5279cD4B1BcBf38853f81b190A806075
 -- SupplyCapIssuanceHook --> 0x0F1171C24B06ADed18d2d23178019A3B256401D3

--- a/product/eth2x/eth2x-product-dash/eth2x-revenue-cost-breakdown.sql
+++ b/product/eth2x/eth2x-product-dash/eth2x-revenue-cost-breakdown.sql
@@ -241,7 +241,7 @@ fa_transactions AS (
         call_tx_hash AS hash,
         call_block_time AS block_time,
         'update fee recipient' AS transaction
-    FROM indexcoop."FeeSplitAdapter_call_updateFeeRecipient"
+    FROM setprotocol_v2."FeeSplitAdapter_call_updateFeeRecipient"
     where contract_address = '\x26F81381018543eCa9353bd081387F68fAE15CeD'
     
     UNION ALL 
@@ -251,7 +251,7 @@ fa_transactions AS (
         evt_tx_hash AS hash,
         evt_block_time AS block_time,
         'transfer ownership' AS transaction
-    FROM indexcoop."FeeSplitAdapter_evt_OwnershipTransferred"
+    FROM setprotocol_v2."FeeSplitAdapter_evt_OwnershipTransferred"
     where contract_address = '\x26F81381018543eCa9353bd081387F68fAE15CeD'
     
     UNION ALL 
@@ -261,7 +261,7 @@ fa_transactions AS (
         evt_tx_hash AS hash,
         evt_block_time AS block_time,
         'accrue fees' AS transaction
-    FROM indexcoop."FeeSplitAdapter_evt_FeesAccrued"
+    FROM setprotocol_v2."FeeSplitAdapter_evt_FeesAccrued"
     where contract_address = '\x26F81381018543eCa9353bd081387F68fAE15CeD'
 
     UNION ALL 
@@ -271,7 +271,7 @@ fa_transactions AS (
         evt_tx_hash AS hash,
         evt_block_time AS block_time,
         'register upgrade' AS transaction
-    FROM indexcoop."FeeSplitAdapter_evt_UpgradeRegistered"
+    FROM setprotocol_v2."FeeSplitAdapter_evt_UpgradeRegistered"
     where contract_address = '\x26F81381018543eCa9353bd081387F68fAE15CeD'
 
     UNION ALL
@@ -281,7 +281,7 @@ fa_transactions AS (
         evt_tx_hash AS hash,
         evt_block_time AS block_time,
         'update caller status' AS transaction
-    FROM indexcoop."FeeSplitAdapter_evt_CallerStatusUpdated"
+    FROM setprotocol_v2."FeeSplitAdapter_evt_CallerStatusUpdated"
     where contract_address = '\x26F81381018543eCa9353bd081387F68fAE15CeD'
 
     UNION ALL
@@ -291,7 +291,7 @@ fa_transactions AS (
         evt_tx_hash AS hash,
         evt_block_time AS block_time,
         'update anyone callable' AS transaction
-    FROM indexcoop."FeeSplitAdapter_evt_AnyoneCallableUpdated"
+    FROM setprotocol_v2."FeeSplitAdapter_evt_AnyoneCallableUpdated"
     where contract_address = '\x26F81381018543eCa9353bd081387F68fAE15CeD'
 ),
 


### PR DESCRIPTION
Dune & Set consolidated all of the traces underneath the `setprotocol_v2` namespace instead of `indexcoop`, and fixed our Dune dashboards to reflect that.

This creates a future issue for a few queries (maybe @Sidheartx 's responsibility?) where some queries might have duplicate rows - this can be solved via a union but we need to both change the query and update it in prod.